### PR TITLE
Add homepage

### DIFF
--- a/rbs2ts.gemspec
+++ b/rbs2ts.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = "Convert rbs to typescript"
   spec.description   = "Convert rbs to typescript"
-  # spec.homepage      = "TODO: Put your gem's website or public repo URL here."
+  spec.homepage      = "https://github.com/mugi-uno/rbs2ts"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.


### PR DESCRIPTION
This PR adds `homepage` to .gemspec which will show a link to this repository on https://rubygems.org/gems/rbs2ts/ .