### PR TITLE
fix: IntersectionType <=> UnionType in README and fixture

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ export type TrueLiteral = true;
 
 export type FalseLiteral = false;
 
-export type UnionType = string & number & boolean;
+export type IntersectionType = string & number & boolean;
 
-export type IntersectionType = string | number | boolean;
+export type UnionType = string | number | boolean;
 
 export type ArrayType = string[];
 

--- a/spec/fixtures/test.rbs
+++ b/spec/fixtures/test.rbs
@@ -12,8 +12,8 @@ type StringLiteral = 'abc'
 type TrueLiteral = true
 type FalseLiteral = false
 
-type UnionType = String & Integer & Bool
-type IntersectionType = String | Integer | Bool
+type IntersectionType = String & Integer & Bool
+type UnionType = String | Integer | Bool
 
 type ArrayType = Array[String]
 


### PR DESCRIPTION
In README.md and spec/fixtures/test.rbs

- Type using `|` is called `IntersectionType`
- Type using `&` is called `UnionType`

which are wrong in TypeScript terms.

This pull request fixes these. I wonder there are the same mistake I haven't noticed.