### PR TITLE
feat: Convert module to namespace of typescript 

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ class Klass
     **String rest_keywords
   ) -> [{ s: String, f: Float }?]
 end
+
+module Module
+  def func: (String, Integer) -> { str: String, int: Integer }
+end
 ```
 
 to TypeScript
@@ -169,6 +173,13 @@ export declare class Klass {
     f: number;
   } | null | undefined)];
 };
+
+export namespace Module {
+  export declare function func(arg1: string, arg2: number): {
+    str: string;
+    int: number;
+  };
+};
 ```
 
 ---
@@ -182,5 +193,5 @@ export declare class Klass {
 - [x] Base Types
 - [x] Method Type (Argument Types and Return Types)
 - [x] Class declaration
-- [ ] Module declaration
+- [x] Module declaration
 - [ ] Interface declaration

--- a/lib/rbs2ts/converter.rb
+++ b/lib/rbs2ts/converter.rb
@@ -3,6 +3,7 @@ end
 
 require 'case_transform'
 
+require 'rbs2ts/converter/helper'
 require 'rbs2ts/converter/declarations'
 require 'rbs2ts/converter/types'
 require 'rbs2ts/converter/members'

--- a/lib/rbs2ts/converter/helper.rb
+++ b/lib/rbs2ts/converter/helper.rb
@@ -1,0 +1,16 @@
+module Rbs2ts
+  module Converter
+    module Helper
+      class << self
+        INDENT = '  '
+
+        def indent(text, level = 1)
+          text
+            .split("\n")
+            .map {|t| "#{INDENT * level}#{t}" }
+            .join("\n")
+        end
+      end
+    end
+  end
+end

--- a/lib/rbs2ts/converter/types.rb
+++ b/lib/rbs2ts/converter/types.rb
@@ -46,18 +46,10 @@ module Rbs2ts
       end
 
       class Record < ConverterBase
-        INDENT = '  '
-        @@nest = 0
-
         def to_ts
-          @@nest = @@nest + 1
-
-          indent = INDENT * @@nest
           field_lines = type.fields.map { |name, type|
-            "#{indent}#{CaseTransform.camel_lower(name.to_s)}: #{Types::Resolver.to_ts(type)};"
+            "#{CaseTransform.camel_lower(name.to_s)}: #{Types::Resolver.to_ts(type)};"
           }
-
-          @@nest = @@nest - 1
 
           return '{}' if field_lines.empty?
 
@@ -65,8 +57,8 @@ module Rbs2ts
 
           ts = <<~CODE
           {
-          #{field_ts}
-          #{INDENT * @@nest}}
+          #{Helper.indent(field_ts)}
+          }
           CODE
     
           ts.chomp

--- a/lib/rbs2ts/version.rb
+++ b/lib/rbs2ts/version.rb
@@ -1,3 +1,3 @@
 module Rbs2ts
-  VERSION = "1.0.0"
+  VERSION = "1.1.0"
 end

--- a/spec/fixtures/test.rbs
+++ b/spec/fixtures/test.rbs
@@ -67,3 +67,7 @@ class Klass
     **String rest_keywords
   ) -> [{ s: String, f: Float }?]
 end
+
+module Module
+  def func: (String, Integer) -> { str: String, int: Integer }
+end

--- a/spec/rbs2ts/converter/declarations_spec.rb
+++ b/spec/rbs2ts/converter/declarations_spec.rb
@@ -53,6 +53,45 @@ RSpec.describe Rbs2ts::Converter::Declarations::Declarations do
     end
   end
 
+  describe 'Module' do
+    it 'convert Module' do
+      expect(TestUtil.to_ts(
+        <<~RBS
+          module Foo
+            def required_positional: (String) -> void
+            def required_positional_name: (String str) -> void
+            def optional_positional: (?String) -> void
+            def optional_positional_name: (?String? str) -> void
+            def rest_positional: (*String, Integer) -> void
+            def rest_positional_name: (*String str, Integer trailing) -> void
+            def rest_positional_only: (*String) -> void
+            def required_keyword: (str: String) -> void
+            def optional_keyword: (?str: String?) -> void
+            def rest_keywords: (**String) -> void
+            def rest_keywords_name: (**String rest) -> void
+          end
+        RBS
+      )).to eq(
+        <<~TS
+          export namespace Foo {
+            export declare function requiredPositional(arg1: string): void;
+            export declare function requiredPositionalName(str: string): void;
+            export declare function optionalPositional(arg1?: string): void;
+            export declare function optionalPositionalName(str?: string | null | undefined): void;
+            export declare function restPositional(arg1: string[], arg2: number): void;
+            export declare function restPositionalName(str: string[], trailing: number): void;
+            export declare function restPositionalOnly(...arg1: string[]): void;
+            export declare function requiredKeyword(arg1: { str: string }): void;
+            export declare function optionalKeyword(arg1: { str?: string | null | undefined }): void;
+            export declare function restKeywords(arg1: { [key: string]: unknown; }): void;
+            export declare function restKeywordsName(arg1: { [key: string]: unknown; }): void;
+          };
+        TS
+        .chomp
+      )
+    end
+  end
+
   describe 'Alias' do
     it 'convert Alias' do
       expect(TestUtil.to_ts(


### PR DESCRIPTION
Convert module to namespace of typescript 

### example

RBS

```
module Module
  def func: (String, Integer) -> { str: String, int: Integer }
end
```

ts

```
export namespace Module {
  export declare function func(arg1: string, arg2: number): {
    str: string;
    int: number;
  };
};
```