### PR TITLE
feat: Convert interface to typescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ end
 module Module
   def func: (String, Integer) -> { str: String, int: Integer }
 end
+
+interface _Interface
+  def func: (String, Integer) -> { str: String, int: Integer }
+end
 ```
 
 to TypeScript
@@ -180,18 +184,11 @@ export namespace Module {
     int: number;
   };
 };
+
+export interface Interface {
+  func(arg1: string, arg2: number): {
+    str: string;
+    int: number;
+  };
+};
 ```
-
----
-
-## ToDo
-
-- [x] Literal type
-- [ ] Interface type
-- [x] Literal type
-- [x] Tuple Type
-- [x] Base Types
-- [x] Method Type (Argument Types and Return Types)
-- [x] Class declaration
-- [x] Module declaration
-- [ ] Interface declaration

--- a/spec/fixtures/test.rbs
+++ b/spec/fixtures/test.rbs
@@ -71,3 +71,7 @@ end
 module Module
   def func: (String, Integer) -> { str: String, int: Integer }
 end
+
+interface _Interface
+  def func: (String, Integer) -> { str: String, int: Integer }
+end

--- a/spec/rbs2ts/converter/declarations_spec.rb
+++ b/spec/rbs2ts/converter/declarations_spec.rb
@@ -92,6 +92,45 @@ RSpec.describe Rbs2ts::Converter::Declarations::Declarations do
     end
   end
 
+  describe 'Interface' do
+    it 'convert Interface' do
+      expect(TestUtil.to_ts(
+        <<~RBS
+          interface _Foo
+            def required_positional: (String) -> void
+            def required_positional_name: (String str) -> void
+            def optional_positional: (?String) -> void
+            def optional_positional_name: (?String? str) -> void
+            def rest_positional: (*String, Integer) -> void
+            def rest_positional_name: (*String str, Integer trailing) -> void
+            def rest_positional_only: (*String) -> void
+            def required_keyword: (str: String) -> void
+            def optional_keyword: (?str: String?) -> void
+            def rest_keywords: (**String) -> void
+            def rest_keywords_name: (**String rest) -> void
+          end
+        RBS
+      )).to eq(
+        <<~TS
+          export interface Foo {
+            requiredPositional(arg1: string): void;
+            requiredPositionalName(str: string): void;
+            optionalPositional(arg1?: string): void;
+            optionalPositionalName(str?: string | null | undefined): void;
+            restPositional(arg1: string[], arg2: number): void;
+            restPositionalName(str: string[], trailing: number): void;
+            restPositionalOnly(...arg1: string[]): void;
+            requiredKeyword(arg1: { str: string }): void;
+            optionalKeyword(arg1: { str?: string | null | undefined }): void;
+            restKeywords(arg1: { [key: string]: unknown; }): void;
+            restKeywordsName(arg1: { [key: string]: unknown; }): void;
+          };
+        TS
+        .chomp
+      )
+    end
+  end
+
   describe 'Alias' do
     it 'convert Alias' do
       expect(TestUtil.to_ts(


### PR DESCRIPTION
Convert module to namespace of typescript

### example

RBS

```
interface _Interface
  def func: (String, Integer) -> { str: String, int: Integer }
end
```


TypeScript

```
export interface Interface {
  func(arg1: string, arg2: number): {
    str: string;
    int: number;
  };
};
```