### PR TITLE
Convert class and alias in module

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,13 @@ class Klass
 end
 
 module Module
+  type AliasType = String
+
   def func: (String, Integer) -> { str: String, int: Integer }
+
+  class NestedClass
+    attr_accessor a: AliasType
+  end
 end
 
 interface _Interface
@@ -179,9 +185,13 @@ export declare class Klass {
 };
 
 export namespace Module {
+  export type AliasType = string;
   export declare function func(arg1: string, arg2: number): {
     str: string;
     int: number;
+  };
+  export declare class NestedClass {
+    a: AliasType;
   };
 };
 

--- a/lib/rbs2ts/converter/declarations.rb
+++ b/lib/rbs2ts/converter/declarations.rb
@@ -35,7 +35,7 @@ module Rbs2ts
         end
 
         def name
-          declaration.name.to_s.gsub(/:/, '')
+          declaration.name.name.to_s.gsub(/:/, '')
         end
     
         private
@@ -89,6 +89,14 @@ module Rbs2ts
 
         def member_to_ts(member)
           case member
+          when ::RBS::AST::Declarations::Class then
+            Converter::Declarations::Class.new(member).to_ts
+          when ::RBS::AST::Declarations::Module then
+            Converter::Declarations::Module.new(member).to_ts
+          when ::RBS::AST::Declarations::Interface then
+            Converter::Declarations::Interface.new(member).to_ts
+          when ::RBS::AST::Declarations::Alias then
+            Converter::Declarations::Alias.new(member).to_ts
           when ::RBS::AST::Members::MethodDefinition
             ts = Converter::Members::MethodDefinition.new(member).to_ts
             "export declare function #{ts}"

--- a/lib/rbs2ts/converter/types.rb
+++ b/lib/rbs2ts/converter/types.rb
@@ -136,7 +136,7 @@ module Rbs2ts
           when 'Bool' then
             Types::Bool.new(type).to_ts
           else
-            type.name.to_s.gsub(/:/, '')
+            type.name.name.to_s.gsub(/:/, '')
           end
         end
       end

--- a/spec/fixtures/test.rbs
+++ b/spec/fixtures/test.rbs
@@ -69,7 +69,13 @@ class Klass
 end
 
 module Module
+  type AliasType = String
+
   def func: (String, Integer) -> { str: String, int: Integer }
+
+  class NestedClass
+    attr_accessor a: AliasType
+  end
 end
 
 interface _Interface

--- a/spec/rbs2ts/converter/declarations_spec.rb
+++ b/spec/rbs2ts/converter/declarations_spec.rb
@@ -69,6 +69,12 @@ RSpec.describe Rbs2ts::Converter::Declarations::Declarations do
             def optional_keyword: (?str: String?) -> void
             def rest_keywords: (**String) -> void
             def rest_keywords_name: (**String rest) -> void
+
+            type AliasType = String
+
+            class Bar
+              attr_reader reader: AliasType
+            end
           end
         RBS
       )).to eq(
@@ -85,6 +91,10 @@ RSpec.describe Rbs2ts::Converter::Declarations::Declarations do
             export declare function optionalKeyword(arg1: { str?: string | null | undefined }): void;
             export declare function restKeywords(arg1: { [key: string]: unknown; }): void;
             export declare function restKeywordsName(arg1: { [key: string]: unknown; }): void;
+            export type AliasType = string;
+            export declare class Bar {
+              readonly reader: AliasType;
+            };
           };
         TS
         .chomp


### PR DESCRIPTION
Convert class and alias in module to typescript

RBS

```
module Module
  type AliasType = String

  def func: (String, Integer) -> { str: String, int: Integer }

  class NestedClass
    attr_accessor a: AliasType
  end
end
```


TypeScript
```
export namespace Module {
  export type AliasType = string;
  export declare function func(arg1: string, arg2: number): {
    str: string;
    int: number;
  };
  export declare class NestedClass {
    a: AliasType;
  };
};
```