### PR TITLE
Avoid typescript reserved words

### DIFF
--- a/lib/rbs2ts/converter/declarations.rb
+++ b/lib/rbs2ts/converter/declarations.rb
@@ -35,7 +35,7 @@ module Rbs2ts
         end
 
         def name
-          declaration.name.name.to_s.gsub(/:/, '')
+          declaration.name.name.to_s
         end
     
         private
@@ -50,7 +50,7 @@ module Rbs2ts
           }.reject(&:empty?).join("\n")
 
           <<~TS
-            export declare class #{name} {
+            export declare class #{Converter::Helper.convert_name(name)} {
             #{Helper.indent(members_ts)}
             };
           TS
@@ -82,7 +82,7 @@ module Rbs2ts
           }.reject(&:empty?).join("\n")
 
           <<~TS
-            export namespace #{name} {
+            export namespace #{Converter::Helper.convert_name(name)} {
             #{Helper.indent(members_ts)}
             };
           TS
@@ -118,7 +118,7 @@ module Rbs2ts
           }.reject(&:empty?).join("\n")
 
           <<~TS
-            export interface #{name.gsub(/_/, '')} {
+            export interface #{Converter::Helper.convert_name(name.gsub(/_/, ''))} {
             #{Helper.indent(members_ts)}
             };
           TS
@@ -137,7 +137,7 @@ module Rbs2ts
   
       class Alias < Base
         def to_ts
-          "export type #{name} = #{Converter::Types::Resolver.to_ts(declaration.type)};"
+          "export type #{Converter::Helper.convert_name(name)} = #{Converter::Types::Resolver.to_ts(declaration.type)};"
         end
       end
   

--- a/lib/rbs2ts/converter/helper.rb
+++ b/lib/rbs2ts/converter/helper.rb
@@ -10,6 +10,28 @@ module Rbs2ts
             .map {|t| "#{INDENT * level}#{t}" }
             .join("\n")
         end
+
+        TS_RESERVED_WORDS = %w(
+          any as boolean break case catch class const constructor continue debugger declare
+          default delete do else enum export extends false finally for from function get if
+          implements import in instanceof interface let module new null number of package
+          private protected public require return set static string super switch symbol
+          this throw true try type typeof var void while with yield
+        )
+
+        def convert_name(org_name)
+          name = org_name.to_s.gsub(/[:@]/, '')
+
+          unless name =~ /^[A-Z]/
+            name = CaseTransform.camel_lower(name)
+          end
+
+          if TS_RESERVED_WORDS.include?(name)
+            "#{name}Type"
+          else
+            name
+          end
+        end
       end
     end
   end

--- a/lib/rbs2ts/converter/members.rb
+++ b/lib/rbs2ts/converter/members.rb
@@ -11,7 +11,7 @@ module Rbs2ts
         end
 
         def name
-          CaseTransform.camel_lower(member.name.to_s.gsub(/:/, ''))
+          Converter::Helper.convert_name(member.name)
         end
     
         private
@@ -21,7 +21,7 @@ module Rbs2ts
 
       class InstanceVariable < Base
         def to_ts
-          "#{name.gsub(/@/, '')}: #{Converter::Types::Resolver.to_ts(member.type)};"
+          "#{name}: #{Converter::Types::Resolver.to_ts(member.type)};"
         end
       end
 

--- a/lib/rbs2ts/converter/types.rb
+++ b/lib/rbs2ts/converter/types.rb
@@ -48,7 +48,7 @@ module Rbs2ts
       class Record < ConverterBase
         def to_ts
           field_lines = type.fields.map { |name, type|
-            "#{CaseTransform.camel_lower(name.to_s)}: #{Types::Resolver.to_ts(type)};"
+            "#{Converter::Helper.convert_name(name)}: #{Types::Resolver.to_ts(type)};"
           }
 
           return '{}' if field_lines.empty?
@@ -136,7 +136,7 @@ module Rbs2ts
           when 'Bool' then
             Types::Bool.new(type).to_ts
           else
-            type.name.name.to_s.gsub(/:/, '')
+            Converter::Helper.convert_name(type.name.name)
           end
         end
       end

--- a/spec/rbs2ts/converter/helper_spec.rb
+++ b/spec/rbs2ts/converter/helper_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe Rbs2ts::Converter::Helper do
+  describe 'indent' do
+    it 'get indented text' do
+      expect(Rbs2ts::Converter::Helper.indent("aaa\nbbb\nccc")).to eq("  aaa\n  bbb\n  ccc")
+    end
+  end
+
+  describe 'convert_name' do
+    it 'remove some charactors' do
+      expect(Rbs2ts::Converter::Helper.convert_name('Foo::Bar')).to eq('FooBar')
+      expect(Rbs2ts::Converter::Helper.convert_name('@val')).to eq('val')
+    end
+
+    it 'convert snakecase to camelcase' do
+      expect(Rbs2ts::Converter::Helper.convert_name('foo_bar_baz')).to eq('fooBarBaz')
+      expect(Rbs2ts::Converter::Helper.convert_name('FooBarBaz')).to eq('FooBarBaz')
+    end
+
+    it 'avoid ts reserved word' do
+      expect(Rbs2ts::Converter::Helper.convert_name('const')).to eq('constType')
+      expect(Rbs2ts::Converter::Helper.convert_name('void')).to eq('voidType')
+    end
+  end
+end


### PR DESCRIPTION
Avoid typescript reserved words.

list↓

```
break
case
catch
class
const
continue
debugger
default
delete
do
else
enum
export
extends
false
finally
for
function
if
import
in
instanceof
new
null
return
super
switch
this
throw
true
try
typeof
var
void
while
with
Strict Mode Reserved Words
as
implements
interface
let
package
private
protected
public
static
yield
Contextual Keywords
any
boolean
constructor
declare
get
module
require
number
set
string
symbol
type
from
of
```

These will added 'Type' to the suffix

I used the following as a reference.
https://github.com/microsoft/TypeScript/issues/2536